### PR TITLE
Fixes #1: Adding compatibility with Magento 2.2

### DIFF
--- a/Model/Transport.php
+++ b/Model/Transport.php
@@ -65,4 +65,12 @@ class Transport extends \Zend_Mail_Transport_Smtp implements \Magento\Framework\
             throw new \Magento\Framework\Exception\MailException(new \Magento\Framework\Phrase($e->getMessage()), $e);
         }
     }
+
+    /**
+     * @inheritdoc
+     */
+    public function getMessage()
+    {
+        return $this->_message;
+    }
 }

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
   "name": "codepeak/magento2-mailtrap",
   "description": "Enable mail testing through Mailtrap.io",
+  "version": "1.1.0",
   "license": "proprietary",
   "authors": [
     {

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,9 @@
     }
   ],
   "minimum-stability": "dev",
-  "require": {},
+  "require": {
+    "magento/module-email": "*"
+  },
   "autoload": {
     "files": [
       "registration.php"

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
-    <preference for="\Magento\Framework\Mail\Transport" type="Codepeak\Mailtrap\Model\Transport"/>
+    <preference for="Magento\Framework\Mail\TransportInterface" type="Codepeak\Mailtrap\Model\Transport"/>
 </config>

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-	<module name="Codepeak_Mailtrap" setup_version="1.0.0">
+	<module name="Codepeak_Mailtrap" setup_version="1.1.0">
 		<sequence>
 			<module name="Magento_Email"/>
 		</sequence>

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,4 +1,8 @@
 <?xml version="1.0" ?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-	<module name="Codepeak_Mailtrap" setup_version="1.0.0"/>
+	<module name="Codepeak_Mailtrap" setup_version="1.0.0">
+		<sequence>
+			<module name="Magento_Email"/>
+		</sequence>
+	</module>
 </config>


### PR DESCRIPTION
Changes:

* Adding missing implementation of `Transport::getMessage()`
* Updating `di.xml` to match Magento best practices (and core code)
* `Magento_Email` is now a dependency to ensure correct load order
* Bumping to version 1.1.0